### PR TITLE
[makeotf_lib] use fixed width integer types from <stdint.h> to solve issues with 64-bit arch

### DIFF
--- a/FDK/Tools/Programs/makeotf/makeotf_lib/api/cffread.h
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/api/cffread.h
@@ -4,6 +4,7 @@ This software is licensed as OpenSource, under the Apache License, Version 2.0. 
 #ifndef CFFREAD_H
 #define CFFREAD_H
 
+#include <stdint.h>
 #include <stddef.h>             /* For size_t */
 
 #define CFF_VERSION 0x010005    /* Library version */
@@ -124,7 +125,7 @@ struct cffStdCallbacks_
        input functions. */
     };
 
-typedef long cffFixed;          /* 16.16 fixed point */
+typedef int32_t cffFixed;          /* 16.16 fixed point */
 
 void cffSetUDV(cffCtx h, int nAxes, cffFixed *UDV);
 void cffSetWV(cffCtx h, int nMasters, cffFixed *WV);

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/api/hotconv.h
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/api/hotconv.h
@@ -4,6 +4,7 @@ This software is licensed as OpenSource, under the Apache License, Version 2.0. 
 #ifndef HOT_H
 #define HOT_H
 
+#include <stdint.h>
 #include <stddef.h>             /* For size_t */
 
 #ifdef __cplusplus
@@ -628,7 +629,7 @@ void hotAddUnencChar(hotCtx g, int iChar, char *name);
    glyphs of a kern pair with a name when one or both glyphs are unencoded.
    This name is subsequently converted into a glyph id by the library. */
 
-typedef long hotFixed;          /* 16.16 fixed point */
+typedef int32_t hotFixed;          /* 16.16 fixed point */
 void hotAddAxisData(hotCtx g, int iAxis,
                     char *type, char *longLabel, char *shortLabel,
                     hotFixed minRange, hotFixed maxRange);

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/cffread/cffread.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/cffread/cffread.c
@@ -5,6 +5,8 @@
  * Compact Font Format (CFF) parser. (Standalone library.)
  */
 
+#include <stdint.h>
+
 #include <string.h>
 #include <stdlib.h>
 #include <limits.h>
@@ -34,7 +36,7 @@ static short exenc[] = {
 #define ABS(v)            ((v) < 0 ? -(v) : (v))
 
 /* 16.16 fixed point arithmetic */
-typedef long Fixed;
+typedef int32_t Fixed;
 #define fixedScale    65536.0
 #define FixedMax    ((Fixed)0x7FFFFFFF)
 #define FixedMin    ((Fixed)0x80000000)

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/common.h
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/common.h
@@ -8,6 +8,8 @@
 #ifndef COMMON_H
 #define COMMON_H
 
+#include <stdint.h>
+
 #include "hotconv.h"
 #include "dynarr.h"
 #include "txops.h"
@@ -56,7 +58,7 @@ typedef unsigned short uFWord;  /* Unsigned metric in font (em) units */
    OFFSET macros allow a simple declaration of both the byte offset field and a
    structure containing the data for that offset. (In header definitions the
    symbol |-> is used as a shorthand for "relative to".) */
-typedef unsigned long LOffset;
+typedef uint32_t LOffset;
 typedef unsigned short Offset;
 #define NULL_OFFSET 0
 #define DCL_OFFSET(type, name) \
@@ -115,7 +117,7 @@ typedef unsigned long Tag;
 
 /* -------------------------------- Typedefs ------------------------------- */
 
-typedef long Fixed;
+typedef int32_t Fixed;
 
 /* Glyph index */
 typedef unsigned short GID;


### PR DESCRIPTION
When compiling on 64-bit without `-m32` flag, `sizeof(long)` can be 8 instead of 4.
The `long` type is used in several type definitions for the `Fixed` data type.
However, the latter is defined in the OpenType spec as a 32-bit number, hence of size 4.

Similarly, `unsigned long` is used here to define `LOffset`, but the OpenType spec defines `ULONG` as a 32 bit unsigned number.

See https://github.com/adobe-type-tools/afdko/issues/57.

``` diff
+#include <stdint.h>

-typedef long Fixed;
+typedef int32_t Fixed;

-typedef long cffFixed;
+typedef int32_t cffFixed;

-typedef long hotFixed;
+typedef int32_t hotFixed;

-typedef unsigned long LOffset;
+typedef uint32_t LOffset;
```
