### PR TITLE
[makeotf/source/cb.c] include io.h and fcntl.h on MINGW32

### DIFF
--- a/FDK/Tools/Programs/makeotf/source/cb.c
+++ b/FDK/Tools/Programs/makeotf/source/cb.c
@@ -70,7 +70,7 @@ char sepch();	/* from WIN.C */
 
 #endif
 
-#ifdef _MSC_VER  /* defined by Microsoft Compiler */
+#if defined(_MSC_VER) || defined(__MINGW32__) /* if Microsoft Compiler or MinGW */
 #include <io.h>
 #include <fcntl.h>
 #include <sys\stat.h>


### PR DESCRIPTION
fixes compilation on Windows when using MinGW gcc

```
makeotf\source\cb.c:703: In function '_tmpfile': error: '_O_BINARY' undeclared
```
